### PR TITLE
Return `nil` rather then a zeroed `Date` instance

### DIFF
--- a/lib/vat_rates/period.rb
+++ b/lib/vat_rates/period.rb
@@ -11,7 +11,7 @@ module VATRates
     end
     
     def effective_from
-      @effective_from || Date.new(0)
+      @effective_from || nil
     end
     
     def to_hash


### PR DESCRIPTION
When 'effective from' date is missing return `nil`.
