### PR TITLE
use ISO_3166 for country codes

### DIFF
--- a/rates/denmark.rb
+++ b/rates/denmark.rb
@@ -1,10 +1,10 @@
 country do
-  
+
   name 'Denmark'
-  code 'DE'
-  
+  code 'DK'
+
   period do
     rate :standard, 25
   end
-  
+
 end

--- a/rates/greece.rb
+++ b/rates/greece.rb
@@ -1,12 +1,12 @@
 country do
-  
+
   name 'Greece'
-  code 'EL'
-  
+  code 'GR'
+
   period do
     rate :reduced1, 6.5
     rate :reduced2, 13
     rate :standard, 23
   end
-  
+
 end

--- a/rates/united_kingdom.rb
+++ b/rates/united_kingdom.rb
@@ -1,8 +1,8 @@
 country do
 
   name 'United Kingdom'
-  code 'UK'
-  
+  code 'GB'
+
   period do
     effective_from 2011, 01, 04
     rate :standard, 20


### PR DESCRIPTION
See http://en.wikipedia.org/wiki/ISO_3166

I'm not sure where the original country codes came from, but there where some countries using the same code (Germany/Denmark). I'm not sure if this is a bug, but it makes it easer to work together with other gems like https://github.com/jim/carmen
