### PR TITLE
Typo in Austria VAT rate definition

### DIFF
--- a/rates/austria.rb
+++ b/rates/austria.rb
@@ -2,7 +2,7 @@ country do
 
   name 'Austria'
   code 'AT'
-  country_code 'AT"'
+  country_code 'AT'
 
   period do
     rate :reduced, 10


### PR DESCRIPTION
There is a typo in Austria VAT rate definition so search for 'AT' returns nil.

```
JSONVAT.country('AT')
=> nil
```
