### PR TITLE
Change United Kingdom code to UK

### DIFF
--- a/rates/united_kingdom.rb
+++ b/rates/united_kingdom.rb
@@ -1,7 +1,7 @@
 country do
 
   name 'United Kingdom'
-  code 'GB'
+  code 'UK'
   country_code 'GB'
 
   period do


### PR DESCRIPTION
To be consistent UK definition should be similar to Greece since both countries have 2 ISO-3166-1-alpha2 (one standard and one exceptionally reserved) codes.

As state here:

http://publications.europa.eu/code/en/en-370100.htm

> The names of the Member States of the European Union must always be written and abbreviated according to the following rules:
> - the two-letter ISO code should be used (ISO 3166 alpha-2), except for Greece and the United Kingdom, for which the abbreviations EL and UK are recommended;

Actually U.K. is referred as UK in most of EU documents, including tax documents.

Related to
https://github.com/adamcooke/json-vat/pull/1
