### PR TITLE
added new standard vat rate for romania per 2016-1-1

### DIFF
--- a/rates/romania.rb
+++ b/rates/romania.rb
@@ -5,6 +5,13 @@ country do
   country_code 'RO'
 
   period do
+	  effective_from 2016, 1, 1
+	  rate :reduced1, 5
+    rate :reduced2, 9
+    rate :standard, 20
+  end
+
+  period do
     rate :reduced1, 5
     rate :reduced2, 9
     rate :standard, 24

--- a/rates/romania.rb
+++ b/rates/romania.rb
@@ -5,8 +5,8 @@ country do
   country_code 'RO'
 
   period do
-	  effective_from 2016, 1, 1
-	  rate :reduced1, 5
+    effective_from 2016, 1, 1
+    rate :reduced1, 5
     rate :reduced2, 9
     rate :standard, 20
   end


### PR DESCRIPTION
Romania reduced its standard VAT rate to 20% per 2016-01-01, see http://www.vatlive.com/vat-rates/european-vat-rates/eu-vat-rates/ .

Thanks for jsonvat.com!