### PR TITLE
Reflect VAT changes in Estonia & Austria

### DIFF
--- a/rates/austria.rb
+++ b/rates/austria.rb
@@ -5,6 +5,13 @@ country do
   country_code 'AT'
 
   period do
+    effective_from 2016, 1, 1
+    rate :reduced, 13
+    rate :standard, 20
+    rate :parking, 12
+  end
+
+  period do
     rate :reduced, 10
     rate :standard, 20
     rate :parking, 12

--- a/rates/austria.rb
+++ b/rates/austria.rb
@@ -6,9 +6,9 @@ country do
 
   period do
     effective_from 2016, 1, 1
-    rate :reduced, 13
+    rate :reduced, 10
     rate :standard, 20
-    rate :parking, 12
+    rate :parking, 13
   end
 
   period do

--- a/rates/estonia.rb
+++ b/rates/estonia.rb
@@ -5,6 +5,12 @@ country do
   country_code "EE"
 
   period do
+    effective_from 2016, 1, 1
+    rate :reduced, 14
+    rate :standard, 20
+  end
+
+  period do
     rate :reduced, 9
     rate :standard, 20
   end

--- a/rates/estonia.rb
+++ b/rates/estonia.rb
@@ -5,12 +5,6 @@ country do
   country_code "EE"
 
   period do
-    effective_from 2016, 1, 1
-    rate :reduced, 14
-    rate :standard, 20
-  end
-
-  period do
     rate :reduced, 9
     rate :standard, 20
   end


### PR DESCRIPTION
Since Jan 1, 2016, the following changes are in effect:

Austria
Reducted rate increased from 10% to 13%

Estonia
Reduced rate increased from 9% to 14%