### PR TITLE
Update Romania's standard rate to 19% (effective 2017-01-01).

### DIFF
--- a/rates/romania.rb
+++ b/rates/romania.rb
@@ -5,6 +5,13 @@ country do
   country_code 'RO'
 
   period do
+    effective_from 2017, 1, 1
+    rate :reduced1, 5
+    rate :reduced2, 9
+    rate :standard, 19
+  end
+
+  period do
     effective_from 2016, 1, 1
     rate :reduced1, 5
     rate :reduced2, 9


### PR DESCRIPTION
As far as I can tell, Romania dropped its standard rate from 20% to 19% this year. Sources:

* [VATlive news](http://www.vatlive.com/vat-news/romania-cuts-vat-to-19-2017/)
* [VATlive 2017 rate list](http://www.vatlive.com/vat-rates/european-vat-rates/)
* [Wikipedia edit (not mine)](https://en.wikipedia.org/w/index.php?title=European_Union_value_added_tax&diff=758094085&oldid=prev)