### PR TITLE
Add 2019-01-01 reduced rate increase for the Netherlands

### DIFF
--- a/rates/netherlands.rb
+++ b/rates/netherlands.rb
@@ -5,6 +5,12 @@ country do
   country_code 'NL'
 
   period do
+    effective_from 2019, 1, 1
+    rate :reduced, 9
+    rate :standard, 21
+  end
+  
+  period do
     effective_from 2012, 10, 1
     rate :reduced, 6
     rate :standard, 21


### PR DESCRIPTION
Sources:

- Official tax office: https://www.belastingdienst.nl/wps/wcm/connect/bldcontenten/belastingdienst/business/vat/vat_in_the_netherlands/calculating_vat/vat_tariffs
- https://www.avalara.com/vatlive/en/vat-news/netherlands-reduced-vat-rate-rise-to-9-2019.html

The Dutch "house of representatives" has voted in favour of the VAT increase [on November 15](https://www.rijksoverheid.nl/actueel/nieuws/2018/11/15/tweede-kamer-stemt-in-met-pakket-belastingplan-2019), and the Senate is expected to vote on it December 18. 

Amazing how there are only 13 days between when it's official and when the government expects everyone to have updated their systems, so, figured I'd send this one in early.