### PR TITLE
Added the whole historical series to italy.rb

### DIFF
--- a/rates/italy.rb
+++ b/rates/italy.rb
@@ -5,9 +5,81 @@ country do
   country_code 'IT'
 
   period do
+    effective_from 1973, 01, 01
+    rate :reduced, 6
+    rate :standard, 12
+  end
+  
+  period do
+    effective_from 1977, 02, 08
+    rate :reduced, 6
+    rate :standard, 14
+  end
+  
+  period do
+    effective_from 1980, 07, 03
+    rate :reduced, 8
+    rate :standard, 15
+  end
+  
+  period do
+    effective_from 1980, 11, 01
+    rate :reduced, 8
+    rate :standard, 14
+  end
+  
+  period do
+    effective_from 1981, 01, 01
+    rate :reduced, 8
+    rate :standard, 15
+  end
+  
+  period do
+    effective_from 1982, 08, 05
+    rate :reduced, 10
+    rate :standard, 18
+  end
+  
+  period do
+    effective_from 1985, 01, 01
+    rate :super_reduced, 2
+    rate :reduced, 9
+    rate :standard, 18
+  end
+  
+  period do
+    effective_from 1988, 08, 01
+    rate :super_reduced, 2
+    rate :reduced, 9
+    rate :standard, 19
+  end
+  
+  period do
+    effective_from 1989, 01, 01
+    rate :super_reduced, 4
+    rate :reduced, 9
+    rate :standard, 19
+  end
+  
+  period do
+    effective_from 1997, 10, 01
+    rate :super_reduced, 4
+    rate :reduced, 10
+    rate :standard, 20
+  end
+  
+  period do
+    effective_from 2011, 09, 17
+    rate :super_reduced, 4
+    rate :reduced, 10
+    rate :standard, 21
+  end
+  
+  period do
+    effective_from 2013, 10, 01
     rate :super_reduced, 4
     rate :reduced, 10
     rate :standard, 22
   end
-
+  
 end


### PR DESCRIPTION
Sources:
https://www.ilsole24ore.com/pdf2010/SoleOnLine5/_Oggetti_Correlati/Documenti/Norme%20e%20Tributi/2011/03/iva-Sk-Frizzera-Aliquote.pdf?uuid=070ee4d0-5c33-11e0-942b-9acc4d1cfe54
https://it.wikipedia.org/wiki/Imposta_sul_valore_aggiunto_(Italia)#Serie_storica_dell'aliquota_IVA_ordinaria_in_vigore_dal_1973

Italy also has an intermediate rate between super reduced an reduced, now set to 5%.